### PR TITLE
Add TAG in the filter of tasks.task.list

### DIFF
--- a/api-reference/tasks/tasks-task-list.md
+++ b/api-reference/tasks/tasks-task-list.md
@@ -123,6 +123,7 @@ Optional. By default, it is sorted in descending order by task identifier.
 - **ONLY_ROOT_TASKS** - only tasks that are not subtasks (root tasks), as well as subtasks of the parent task to which the current user does not have access (Y\|N).
 - **STAGE_ID** - stage;
 - **UF_CRM_TASK** - CRM entities;
+- **TAG** - Tasks Tags;
 
 Before the filter field name, a filtering type can be specified:
 - "!" - not equal


### PR DESCRIPTION
It was missing to insert that there is the possibility to filter by tags, which are defined when creating a task or in the comment with the # before the term.

Like this image. 
<img width="266" height="176" alt="image" src="https://github.com/user-attachments/assets/4b23531a-1470-4133-9fb4-1a5733cd9cad" />

I tested and this works normally, so I think that you only forgot to add in the docs. 